### PR TITLE
feat: emergency_id 발급 및 이미지 업로드 API 추가

### DIFF
--- a/api/v1/hw.py
+++ b/api/v1/hw.py
@@ -6,7 +6,7 @@ from services.hw_services.storage_service import upload_image_to_firebase
 from services.hw_services.auto_describe_service import generate_auto_description
 from services.hw_services.emergency_service import create_emergency
 from typing import Dict
-
+from services.hw_services.emergency_img_service import handle_emergency_image
 
 
 router = APIRouter(tags=["Hardware"])
@@ -59,3 +59,24 @@ async def get_emergency_id(request: Dict[str, str] = Body(...)):
             "status": "error",
             "message": str(e)
         }
+
+
+@router.post("/emergency_img")
+async def emergency_img(
+    device_id: str = Form(...),
+    emergency_id: str = Form(...),
+    image: UploadFile = File(...)
+):
+    """
+    비상 상황 이미지 전송 및 contents 저장 API
+    """
+    image_url = await upload_image_to_firebase(image)
+
+    final_emergency_id = await handle_emergency_image(device_id, emergency_id, image_url)
+
+    return {
+        "status": "success",
+        "emergency_id": final_emergency_id
+    }
+        
+        

--- a/api/v1/hw.py
+++ b/api/v1/hw.py
@@ -1,9 +1,13 @@
-from fastapi import APIRouter, UploadFile, File, Form
+from fastapi import APIRouter, UploadFile, File, Form, Body
 from fastapi.responses import StreamingResponse
 import io
 from services.hw_services.device_service import get_device_by_id, create_content, save_description_to_firestore
 from services.hw_services.storage_service import upload_image_to_firebase
 from services.hw_services.auto_describe_service import generate_auto_description
+from services.hw_services.emergency_service import create_emergency
+from typing import Dict
+
+
 
 router = APIRouter(tags=["Hardware"])
 
@@ -37,3 +41,21 @@ async def auto_describe(device_id : str = Form(...), image : UploadFile = File(.
         media_type="audio/mpeg",
         headers={"Content-Disposition" : "inline; filename = description.mp3"}
     )
+
+@router.post("/get_emergency_id")
+async def get_emergency_id(request: Dict[str, str] = Body(...)):
+    device_id = request.get("device_id")
+    if not device_id:
+        return {"status": "error", "message": "device_id is required"}
+    
+    try:
+        emergency_id = await create_emergency(device_id)
+        return {
+            "status": "success",
+            "emergency_id": emergency_id
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": str(e)
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
+click==8.1.8
+h11==0.16.0
+python-multipart==0.0.20
+typing_extensions==4.13.2
+uvicorn==0.34.2
+python-dotenv==1.1.0
 fastapi==0.115.12
-pymongo==4.11.3
-motor===3.7.0
-uvicorn==0.34.0
-python-dotenv
+firebase-admin==6.8.0

--- a/services/hw_services/device_service.py
+++ b/services/hw_services/device_service.py
@@ -12,8 +12,8 @@ async def get_device_by_id(device_id : str):
     
     return docs_list[0].reference
 
-#2. contents 문서 생성 ( 이미지 업로드 후 호출)
-async def create_content(device_ref, device_id : str, image_url :str):
+#2. contents 문서 생성 ( 이미지 업로드 후 호출) # 기본값은 False/ 비상 상황 이미지 업로드 시 True 4.27 정수영 수정
+async def create_content(device_ref, device_id : str, image_url :str, is_emergency: bool = False):
     content_ref = device_ref.collection("contents").document()
     content_ref.set({
         "device_id": device_id,
@@ -21,7 +21,7 @@ async def create_content(device_ref, device_id : str, image_url :str):
         "created_at": datetime.utcnow().isoformat(),
         "question_text": "",
         "gpt_response": "",
-        "is_emergency": False
+        "is_emergency": is_emergency
     })
     return content_ref
 

--- a/services/hw_services/emergency_img_service.py
+++ b/services/hw_services/emergency_img_service.py
@@ -1,0 +1,44 @@
+
+from firebase_admin import firestore
+from core.firebase import db
+from services.hw_services.device_service import get_device_by_id, create_content
+from datetime import datetime
+from fastapi import HTTPException
+
+async def handle_emergency_image(device_id: str, emergency_id: str, image_url: str):
+    # 디바이스 문서 찾기
+    device_ref = await get_device_by_id(device_id)
+
+    # 최신 location_id 찾기
+    locations_ref = device_ref.collection("locations")
+    latest_location_query = locations_ref.order_by("recorded_at", direction=firestore.Query.DESCENDING).limit(1)
+    latest_location_docs = latest_location_query.stream()
+
+    location_id = None
+    for doc in latest_location_docs:
+        location_id = doc.id
+        break
+
+    if not location_id:
+        raise HTTPException(status_code=404, detail="최근 위치 정보 없음")
+
+    # contents 문서 생성 (is_emergency=True)
+    content_ref = await create_content(
+        device_ref=device_ref,
+        device_id=device_id,
+        image_url=image_url,
+        is_emergency=True
+    )
+
+    # emergency 문서에 contents_id 추가
+    emergency_ref = device_ref.collection("emergency").document(emergency_id)
+    emergency_doc = emergency_ref.get()
+
+    if not emergency_doc.exists:
+        raise HTTPException(status_code=404, detail="emergency_id 없음")
+
+    emergency_ref.update({
+        "contents_id": firestore.ArrayUnion([content_ref.id])
+    })
+
+    return emergency_id

--- a/services/hw_services/emergency_service.py
+++ b/services/hw_services/emergency_service.py
@@ -16,7 +16,7 @@ async def create_emergency(device_id: str) -> str:
     if not device_doc:
         raise ValueError(f"Device with ID {device_id} not found")
 
-    device_ref = device_doc.reference  # <- 이 문서 경로를 기반으로 emergency 저장
+    device_ref = device_doc.reference  # <- 디바이스 문서
 
     # 2. locations에서 최신 recorded_at 문서 찾기
     locations_ref = device_ref.collection("locations")
@@ -31,10 +31,19 @@ async def create_emergency(device_id: str) -> str:
     if not location_id:
         raise ValueError("최근 위치 정보가 존재하지 않습니다.")
 
-    # 3. emergency 서브컬렉션에 저장 (← 여기 핵심)
+    # ✅ 3. contents에서 is_emergency=True인 최근 5개 문서 ID 가져오기
+    contents_ref = device_ref.collection("contents")
+    emergency_contents_query = contents_ref.where("is_emergency", "==", True).order_by("created_at", direction=firestore.Query.DESCENDING).limit(5)
+    emergency_contents_docs = emergency_contents_query.stream()
+
+    contents_id_list = []
+    for doc in emergency_contents_docs:
+        contents_id_list.append(doc.id)
+
+    # 4. emergency 서브컬렉션에 저장
     emergency_data = {
         "triggered_at": datetime.utcnow(),
-        "contents_id": [],
+        "contents_id": contents_id_list,
         "location_id": location_id
     }
 

--- a/services/hw_services/emergency_service.py
+++ b/services/hw_services/emergency_service.py
@@ -1,0 +1,44 @@
+from firebase_admin import firestore
+from datetime import datetime
+
+async def create_emergency(device_id: str) -> str:
+    db = firestore.client()
+
+    # 1. device_id 필드로 devices 문서 검색
+    query = db.collection('devices').where('device_id', '==', device_id).limit(1)
+    docs = query.stream()
+
+    device_doc = None
+    for doc in docs:
+        device_doc = doc
+        break
+
+    if not device_doc:
+        raise ValueError(f"Device with ID {device_id} not found")
+
+    device_ref = device_doc.reference  # <- 이 문서 경로를 기반으로 emergency 저장
+
+    # 2. locations에서 최신 recorded_at 문서 찾기
+    locations_ref = device_ref.collection("locations")
+    latest_location_query = locations_ref.order_by("recorded_at", direction=firestore.Query.DESCENDING).limit(1)
+    latest_location_docs = latest_location_query.stream()
+
+    location_id = None
+    for doc in latest_location_docs:
+        location_id = doc.id
+        break
+
+    if not location_id:
+        raise ValueError("최근 위치 정보가 존재하지 않습니다.")
+
+    # 3. emergency 서브컬렉션에 저장 (← 여기 핵심)
+    emergency_data = {
+        "triggered_at": datetime.utcnow(),
+        "contents_id": [],
+        "location_id": location_id
+    }
+
+    emergency_ref = device_ref.collection("emergency").document()
+    emergency_ref.set(emergency_data)
+
+    return emergency_ref.id

--- a/services/hw_services/emergency_service.py
+++ b/services/hw_services/emergency_service.py
@@ -31,19 +31,10 @@ async def create_emergency(device_id: str) -> str:
     if not location_id:
         raise ValueError("최근 위치 정보가 존재하지 않습니다.")
 
-    # ✅ 3. contents에서 is_emergency=True인 최근 5개 문서 ID 가져오기
-    contents_ref = device_ref.collection("contents")
-    emergency_contents_query = contents_ref.where("is_emergency", "==", True).order_by("created_at", direction=firestore.Query.DESCENDING).limit(5)
-    emergency_contents_docs = emergency_contents_query.stream()
-
-    contents_id_list = []
-    for doc in emergency_contents_docs:
-        contents_id_list.append(doc.id)
-
-    # 4. emergency 서브컬렉션에 저장
+    # 3. emergency 서브컬렉션에 저장 (← 여기 핵심)
     emergency_data = {
         "triggered_at": datetime.utcnow(),
-        "contents_id": contents_id_list,
+        "contents_id": [],
         "location_id": location_id
     }
 

--- a/services/hw_services/storage_service.py
+++ b/services/hw_services/storage_service.py
@@ -5,7 +5,7 @@ async def upload_image_to_firebase(image_file) -> str:
     """
     이미지 파일을 firebase Storage에 업로드하고 공개 URL로 변환
     """
-    filename = f"images/{uuid.uuid4()}.jpg"
+    filename = f"images/{uuid.uuid4()}.png" # .png 확장자 파일로 고정. 4.27 정수영 수정
     blob = bucket.blob(filename)
 
     # 이미지 파일의 내용을 읽어서 업로드

--- a/tests/test_create_dummy_content.py
+++ b/tests/test_create_dummy_content.py
@@ -1,0 +1,32 @@
+import pytest
+from datetime import datetime
+
+# 🔥 core/firebase.py를 import 해서 초기화된 db를 사용
+import core.firebase
+
+db = core.firebase.db  # core에서 생성한 Firestore 클라이언트 사용
+
+def create_dummy_content():
+    contents_ref = db.collection("devices").document("yR74URDoRqdg2xvrLhiV").collection("contents")
+    dummy_data = {
+        "device_id": "test_device",
+        "guardian_name": "홍길동",
+        "guardian_phone": "010-1234-5678",
+        "user_name": "테스트유저",
+        "created_at": datetime.utcnow(),
+    }
+    doc_ref = contents_ref.document()
+    doc_ref.set(dummy_data)
+    return doc_ref.id
+
+# ✅ 유닛 테스트 함수
+def test_create_dummy_content():
+    content_id = create_dummy_content()
+    assert content_id is not None
+    doc = db.collection("devices").document("yR74URDoRqdg2xvrLhiV").collection("contents").document(content_id).get()
+    assert doc.exists
+    data = doc.to_dict()
+    assert data["device_id"] == "test_device"
+    assert data["guardian_name"] == "홍길동"
+    assert data["guardian_phone"] == "010-1234-5678"
+    assert data["user_name"] == "테스트유저"

--- a/tests/test_create_dummy_content.py
+++ b/tests/test_create_dummy_content.py
@@ -9,11 +9,12 @@ db = core.firebase.db  # core에서 생성한 Firestore 클라이언트 사용
 def create_dummy_content():
     contents_ref = db.collection("devices").document("yR74URDoRqdg2xvrLhiV").collection("contents")
     dummy_data = {
-        "device_id": "test_device",
-        "guardian_name": "홍길동",
-        "guardian_phone": "010-1234-5678",
-        "user_name": "테스트유저",
         "created_at": datetime.utcnow(),
+        "gpt_response": "that is sakura tree",
+        "image_url": "2525",
+        "is_emergency": False, # 더미 데이터 생성 시 False/True 설정 / 
+        "location_id": "jAtxAVZwkikJXbWC9LXV",
+        "question_text": "what is that tree?"
     }
     doc_ref = contents_ref.document()
     doc_ref.set(dummy_data)
@@ -26,7 +27,8 @@ def test_create_dummy_content():
     doc = db.collection("devices").document("yR74URDoRqdg2xvrLhiV").collection("contents").document(content_id).get()
     assert doc.exists
     data = doc.to_dict()
-    assert data["device_id"] == "test_device"
-    assert data["guardian_name"] == "홍길동"
-    assert data["guardian_phone"] == "010-1234-5678"
-    assert data["user_name"] == "테스트유저"
+    assert data["gpt_response"] == "that is sakura tree"
+    assert data["image_url"] == "2525"
+    assert data["is_emergency"] is False # 더미 데이터 생성 시 False/True 설정 / 위의 함수와 동일하게 설정
+    assert data["location_id"] == "jAtxAVZwkikJXbWC9LXV"
+    assert data["question_text"] == "what is that tree?"


### PR DESCRIPTION
## 작업 내용
- 디바이스 ID(device_id)를 기반으로 새로운 emergency_id를 발급하는 API(`/api/v1/hw/get_emergency_id`) 추가
- 비상 상황(emergency)에 대응하는 이미지를 업로드하고 contents에 추가하는 API(`/api/v1/hw/emergency_img`) 추가

## 주요 변경 사항
- Firebase Firestore에 emergency 문서 생성 및 contents_id 관리 로직 구현
- Firebase Storage에 이미지 업로드 및 public URL 저장 기능 구현
- 비상 이미지지 업로드 후에 emergency 문서의 contents_id 배열에 id를 추가하여 관리

## 테스트 방법
- Postman을 통해 device_id를 전송하여 emergency_id 발급 확인
- 발급받은 emergency_id로 이미지 업로드 요청하여 contents 추가 및 emergency 업데이트 확인

## 참고 사항
- "created_at": datetime.utcnow() 관련, 포맷 통합 관련 상의 예정.
- 공용코드 수정 "4.27 정수영 수정"
 - /services/hw_services/device_service.py : 비상 상황 이미지 업로드 시 create_content에 True로 매개변수 할당 가능하도록 수정
 - /services/hw_services/storage_service.py : .png 확장자 파일로 고정
