### PR TITLE
feat: 디바이스 로그인 및 비상 푸시 알림 API 구현

### DIFF
--- a/api/v1/client.py
+++ b/api/v1/client.py
@@ -6,6 +6,8 @@ from models.client_models import GPSTraceResponse
 from services.client_services.device_info_service import get_device_info
 from services.client_services.gps_trace_service import get_recent_gps_trace
 from services.client_services.emergency_service import get_emergency_image_urls
+from services.client_services.push_emergency_service import send_emergency_push
+
 from typing import List
 
 router = APIRouter(tags=["Client"])
@@ -54,3 +56,13 @@ async def get_emergency_imglist(
             "status": "error",
             "message": str(e)
         }
+
+@router.post("/push/emergency")
+async def push_emergency(
+    device_id: str = Body(..., embed=True),
+    emergency_id: str = Body(..., embed=True)
+):
+    """
+    FCM HTTP v1 기반 푸시 알림 전송 API
+    """
+    return await send_emergency_push(device_id, emergency_id)

--- a/api/v1/client.py
+++ b/api/v1/client.py
@@ -8,6 +8,7 @@ from services.client_services.device_info_service import get_device_info
 from services.client_services.gps_trace_service import get_recent_gps_trace
 from services.client_services.emergency_service import get_emergency_image_urls
 from services.client_services.push_emergency_service import send_emergency_push
+from services.client_services.login_service import login_and_save_token
 
 from typing import List
 
@@ -72,3 +73,7 @@ async def push_emergency(request: EmergencyPushRequest):
         device_id=request.device_id,
         emergency_id=request.emergency_id
     )
+    
+@router.post("/login")
+async def login_device(device_id: str = Body(..., embed=True), fcm_token: str = Body(..., embed=True)):
+    return await login_and_save_token(device_id, fcm_token)

--- a/api/v1/client.py
+++ b/api/v1/client.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Body
 from models.client_models import ContentDetailResponse
 from services.client_services.content_detail_service import get_content_detail
 from models.client_models import DeviceInfoResponse
 from models.client_models import GPSTraceResponse
+from models.client_models import EmergencyPushRequest
 from services.client_services.device_info_service import get_device_info
 from services.client_services.gps_trace_service import get_recent_gps_trace
 from services.client_services.emergency_service import get_emergency_image_urls
@@ -30,12 +31,12 @@ async def device_info(device_id: str = Query(..., description="디바이스 ID")
 
     return DeviceInfoResponse(**result)
 
-@router.get("/gps_trace", response_model= GPSTraceResponse)
+@router.get("/gps_trace", response_model=GPSTraceResponse)
 async def gps_trace(device_id: str = Query(..., description="조회할 디바이스 ID")):
     """
     보호자가 특정 device_id에 대해 최근 1시간 이내 GPS 위치 타임라인을 조회
     """
-    gps_data =  await get_recent_gps_trace(device_id)
+    gps_data = await get_recent_gps_trace(device_id)
     return {"gps": gps_data}
 
 @router.get("/get_emergency_imglist")
@@ -58,11 +59,16 @@ async def get_emergency_imglist(
         }
 
 @router.post("/push/emergency")
-async def push_emergency(
-    device_id: str = Body(..., embed=True),
-    emergency_id: str = Body(..., embed=True)
-):
+async def push_emergency(request: EmergencyPushRequest):
     """
     FCM HTTP v1 기반 푸시 알림 전송 API
+    
+    Args:
+        request (EmergencyPushRequest): 푸시 알림 요청 데이터
+            - device_id: 디바이스 ID
+            - emergency_id: 비상 상황 ID
     """
-    return await send_emergency_push(device_id, emergency_id)
+    return await send_emergency_push(
+        device_id=request.device_id,
+        emergency_id=request.emergency_id
+    )

--- a/models/client_models.py
+++ b/models/client_models.py
@@ -22,3 +22,7 @@ class GPSItem(BaseModel):
 
 class GPSTraceResponse(BaseModel):
     gps : List[GPSItem]
+
+class EmergencyPushRequest(BaseModel):
+    device_id: str
+    emergency_id: str

--- a/services/client_services/login_service.py
+++ b/services/client_services/login_service.py
@@ -1,0 +1,16 @@
+from firebase_admin import firestore
+from fastapi import HTTPException
+
+async def login_and_save_token(device_id: str, fcm_token: str) -> dict:
+    db = firestore.client()
+
+    query = db.collection("devices").where("device_id", "==", device_id).limit(1)
+    docs = list(query.stream())
+
+    if not docs:
+        raise HTTPException(status_code=404, detail="디바이스를 찾을 수 없습니다.")
+
+    device_ref = docs[0].reference
+    device_ref.update({"fcm_token": fcm_token})
+
+    return {"status": "success"}

--- a/services/client_services/push_emergency_service.py
+++ b/services/client_services/push_emergency_service.py
@@ -1,0 +1,55 @@
+import os
+import json
+import aiohttp
+from fastapi import HTTPException
+from google.oauth2 import service_account
+from google.auth.transport.requests import Request
+
+# 서비스 계정 JSON 경로
+SERVICE_ACCOUNT_FILE = os.getenv("FIREBASE_CREDENTIAL_PATH")
+CLIENT_FCM_TOKEN = os.getenv("CLIENT_FCM_TOKEN") # ???
+PROJECT_ID = os.getenv("FIREBASE_PROJECT_ID")  # 예: "sorivision-50058"
+
+SCOPES = ["https://www.googleapis.com/auth/firebase.messaging"]
+
+
+def get_access_token():
+    credentials = service_account.Credentials.from_service_account_file(
+        SERVICE_ACCOUNT_FILE, scopes=SCOPES
+    )
+    credentials.refresh(Request())
+    return credentials.token
+
+
+async def send_emergency_push(device_id: str, emergency_id: str):
+    if not CLIENT_FCM_TOKEN or not PROJECT_ID:
+        raise HTTPException(status_code=500, detail="필수 환경변수가 누락되었습니다.")
+
+    access_token = get_access_token()
+    url = f"https://fcm.googleapis.com/v1/projects/{PROJECT_ID}/messages:send"
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json"
+    }
+
+    message = {
+        "message": {
+            "token": CLIENT_FCM_TOKEN,
+            "notification": {
+                "title": "🚨 비상 상황 발생",
+                "body": f"디바이스 {device_id}에서 긴급 상황이 발생했습니다."
+            },
+            "data": {
+                "device_id": device_id,
+                "emergency_id": emergency_id
+            }
+        }
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, headers=headers, data=json.dumps(message)) as resp:
+            if resp.status != 200:
+                error = await resp.text()
+                raise HTTPException(status_code=resp.status, detail=f"FCM Error: {error}")
+            return {"status": "success"}

--- a/services/client_services/push_emergency_service.py
+++ b/services/client_services/push_emergency_service.py
@@ -39,21 +39,10 @@ async def send_emergency_push(device_id: str, emergency_id: str):
         raise HTTPException(status_code=404, detail="디바이스를 찾을 수 없습니다.")
     
     device_data = device_doc[0].to_dict()
-    guardian_id = device_data.get('guardian_id')
-    
-    if not guardian_id:
-        raise HTTPException(status_code=404, detail="디바이스에 연결된 보호자가 없습니다.")
-    
-    # 보호자의 FCM 토큰 조회
-    guardian_doc = db.collection('guardians').document(guardian_id).get()
-    if not guardian_doc.exists:
-        raise HTTPException(status_code=404, detail="보호자 정보를 찾을 수 없습니다.")
-    
-    guardian_data = guardian_doc.to_dict()
-    fcm_token = guardian_data.get('fcm_token')
+    fcm_token = device_data.get('fcm_token')
     
     if not fcm_token:
-        raise HTTPException(status_code=400, detail="보호자의 FCM 토큰이 등록되지 않았습니다.")
+        raise HTTPException(status_code=400, detail="디바이스의 FCM 토큰이 등록되지 않았습니다.")
 
     # FCM 메시지 전송
     access_token = get_access_token()


### PR DESCRIPTION
- /api/v1/client/login: FCM 토큰 등록 포함 디바이스 로그인 기능 추가
- /api/v1/client/push/emergency: FCM HTTP v1 기반 보호자 푸시 알림 전송 기능 추가
- Firestore 기반 device_id → fcm_token 매핑 구조 적용
- 서비스 계정 기반 액세스 토큰 발급 로직 포함
